### PR TITLE
Fix sidebar drawer overlap

### DIFF
--- a/jazzy/style.css
+++ b/jazzy/style.css
@@ -902,7 +902,7 @@ textarea {
     height: 100%;
     width: 0;
     position: fixed;
-    z-index: 1;
+    z-index: 100;
     top: 0;
     right: -5px;
     background-color: var(--white);


### PR DESCRIPTION
### Description
Fixed elements such as the mp3 player and logo overlapping the sidebar drawer when opened.

### Testing
Open the sidebar drawer and check if any elements are overlapping.

### Other
@CDennien could you please review my fix for this issue?