### PR TITLE
Improve method of adding socials

### DIFF
--- a/jazzy/footer.php
+++ b/jazzy/footer.php
@@ -16,10 +16,21 @@
         <?php
 
             // custom footer links
-            foreach ( wp_get_nav_menu_items( 'footer' ) as $menuItem ) {
-                echo '<a href="' . $menuItem->url . '"><i class="' . $menuItem->title . '"></i></a>';
+            if (get_theme_mod( 'facebook-url' )) {
+                echo '<a href="' . get_theme_mod( 'facebook-url' ) . '"><i class="fa fa-facebook"></i></a>';
             }
 
+            if (get_theme_mod( 'instagram-url' )) {
+                echo '<a href="' . get_theme_mod( 'instagram-url' ) . '"><i class="fab fa-instagram-square"></i></a>';
+            }
+
+            if (get_theme_mod( 'phone-number' )) {
+                echo '<a href="tel:' . get_theme_mod( 'phone-number' ) . '"><i class="fas fa-phone"></i></a>';
+            }
+
+            if (get_theme_mod( 'email-address' )) {
+                echo '<a href="mailto:' . get_theme_mod( 'email-address' ) . '"><i class="fas fa-envelope"></i></a>';
+            }
         ?>
     </div>
     <div class="site-info">

--- a/jazzy/functions.php
+++ b/jazzy/functions.php
@@ -54,12 +54,6 @@ if ( ! function_exists( 'jazzy_setup' ) ) :
 			)
 		);
 
-		// Add custom footer menu
-        function wpb_custom_new_menu() {
-            register_nav_menu('footer-menu',__( 'Footer Menu' ));
-        }
-        add_action( 'init', 'wpb_custom_new_menu' );
-
 		/*
 		 * Switch default core markup for search form, comment form, and comments
 		 * to output valid HTML5.

--- a/jazzy/inc/customizer.php
+++ b/jazzy/inc/customizer.php
@@ -58,6 +58,31 @@ function jazzy_customize_register( $wp_customize ) {
 
     $wp_customize->add_setting( 'audio-url', array( 'default' => '' ) );
     $wp_customize->add_control( new WP_Customize_Control( $wp_customize, 'audio-url', array( 'label' => __( 'URL', 'jazzy' ), 'section' => 'media-player', 'settings' => 'audio-url', ) ) );
+
+    // Footer Socials
+    $wp_customize->add_section(
+        'footer-socials',
+        array(
+            'title' => __('Footer Socials', 'jazzy'),
+            'priority' => 30,
+            'description' => __('Add social media accounts to the footer.')
+        )
+    );
+    // facebook, instagram, phone, email
+    $wp_customize->add_setting( 'facebook-url', array( 'default' => ''));
+    $wp_customize->add_control( new WP_Customize_Control( $wp_customize, 'facebook-url', array( 'label' => __( 'Facebook profile URL', 'jazzy'), 'section' => 'footer-socials', 'settings' => 'facebook-url', )));
+
+    // instagram
+    $wp_customize->add_setting( 'instagram-url', array( 'default' => ''));
+    $wp_customize->add_control( new WP_Customize_Control( $wp_customize, 'instagram-url', array( 'label' => __( 'Instagram profile URL', 'jazzy'), 'section' => 'footer-socials', 'settings' => 'instagram-url', )));
+
+    // phone
+    $wp_customize->add_setting( 'phone-number', array( 'default' => ''));
+    $wp_customize->add_control( new WP_Customize_Control( $wp_customize, 'phone-number', array( 'label' => __( 'Phone number', 'jazzy'), 'section' => 'footer-socials', 'settings' => 'phone-number', )));
+
+    // email
+    $wp_customize->add_setting( 'email-address', array( 'default' => ''));
+    $wp_customize->add_control( new WP_Customize_Control( $wp_customize, 'email-address', array( 'label' => __( 'Email address', 'jazzy'), 'section' => 'footer-socials', 'settings' => 'email-address', )));
 }
 add_action( 'customize_register', 'jazzy_customize_register' );
 


### PR DESCRIPTION
### Description
Added a menu to theme customisation that allows for easy additions to the footer social menu.

### Testing
Add socials using the theme customiser and check that they appear in the footer correctly.

### Other
Hi, @CDennien I've updated the implementation of the footer socials (#21) to use the theme customiser instead of menus. Could you please review these changes? If you're happy with this pull request please merge and close the branch.